### PR TITLE
Auto-updates: add Harpy and Siren

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,7 @@ Last update: 2015-01-09
     - [Macros utilities](#macros-utilities)
     - [Low level](#low-level)
   - [Dependency Management](#dependency-management)
+  - [Auto-updates](#auto-updates)
   - [Design Patterns](#design-patterns)
     - [Promises/Futures/Deferred](#promisesfuturesdeferred)
   - [Algorithms](#algorithms)
@@ -94,7 +95,6 @@ Last update: 2015-01-09
   - [Code Examples](#code-examples)
     - [Low-level](#low-level)
   - [OSX](#osx)
-    - [Auto-updating OS X apps](#auto-updating-os-x-apps)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -235,6 +235,20 @@ element of a list
 * [Carthage](https://github.com/Carthage/Carthage)
 
 > A simple, decentralized dependency manager for Cocoa
+
+## Auto-updates
+
+* [Harpy](https://github.com/ArtSabintsev/Harpy) and [Siren](https://github.com/ArtSabintsev/Siren)
+
+> Notify users when a new version of your iOS app is available, and prompt them with the App Store link.
+
+[Squirrel.Mac](https://github.com/Squirrel/Squirrel.Mac)
+
+> :shipit: Cocoa framework for updating OS X apps :shipit:
+
+[Sparkle](https://github.com/sparkle-project/Sparkle)
+
+> A software update framework for OS X. http://sparkle-project.org/
 
 ## Design Patterns
 
@@ -1085,14 +1099,4 @@ Controller working as if it were all in a UITableViewController.
 > Creating an iOS app in pure C
 
 ## OSX
-
-### Auto-updating OS X apps
-
-[Squirrel.Mac](https://github.com/Squirrel/Squirrel.Mac)
-
-> :shipit: Cocoa framework for updating OS X apps :shipit:
-
-[Sparkle](https://github.com/sparkle-project/Sparkle)
-
-> A software update framework for OS X. http://sparkle-project.org/
 


### PR DESCRIPTION
# Harpy
### Notify users when a new version of your app is available, and prompt them with the App Store link.

**Harpy** checks a user's currently installed version of your iOS app against the version that is currently available in the App Store. If a new version is available, an alert can be presented to the user informing them of the newer version, and giving them the option to update the application. 

# Siren
### Notify users when a new version of your app is available, and prompt them with the App Store link.

**Siren** checks a user's currently installed version of your iOS app against the version that is currently available in the App Store.

If a new version is available, an alert can be presented to the user informing them of the newer version, and giving them the option to update the application. Alternatively, Siren can notify your app programmatically, enabling you to inform the user through alternative means, such as a custom interface.

- Siren is built to work with the [**Semantic Versioning**](http://semver.org/) system.
- Siren is a Swift language port of [**Harpy**](http://github.com/ArtSabintsev/Harpy), an Objective-C library that achieves the same functionality.
- Siren is actively maintained by [**Arthur Sabintsev**](http://github.com/ArtSabintsev) and [**Aaron Brager**](http://twitter.com/getaaron).
