### PR TITLE
Testing: add JPSimulatorHacks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -681,6 +681,10 @@ interactions, inspired by VCR for ruby
 > RedGreen is an extension library for SenTestKit that makes the test
 output easier to parse by humans.
 
+* [JPSimulatorHacks](https://github.com/plu/JPSimulatorHacks)
+
+> Automatically grant access to addressbook/photos in your tests (Simulator only)
+
 * [mneorr/XCPretty](https://github.com/mneorr/XCPretty)
 
 > Flexible and fast xcodebuild formatter


### PR DESCRIPTION
# JPSimulatorHacks

Hack the Simulator in your tests (grant access to photos, contacts, ...).

Did you ever have the problem that your code was wrapping the `AddressBook` or
the `ALAssetsLibrary` APIs? Running tests can be annoying then. There's this
`UIAlertView` asking the user to grant access to the contacts and photos,
which blocks and breaks your tests. Using `JPSimulatorHacks` you can easily
grant this access before running your tests.