### PR TITLE
Build Tools: google/bazel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,7 @@ Last update: 2015-03-28
   - [Debugging](#debugging)
     - [Logging](#logging-1)
     - [Core Data](#core-data-1)
+  - [Build Tools](#build-tools)
   - [Testing](#testing)
     - [Testing frameworks](#testing-frameworks)
     - [Test Automation](#test-automation)
@@ -618,6 +619,12 @@ ATLog(@"%@",CGPointMake(1,1)); // No need for NSStringFromCGPoint.
 > GDCoreDataConcurrencyDebugging helps you find cases where
 NSManagedObject's are being called on the wrong thread or dispatch
 queue.
+
+## Build Tools
+
+* [bazel](https://github.com/google/bazel)
+
+> Correct, reproducible, and fast builds for everyone.
 
 ## Testing
 


### PR DESCRIPTION
# [Bazel](http://bazel.io) ([Alpha](http://bazel.io/docs/roadmap.html#alpha))

*{Fast, Correct} - Choose two*

Bazel is a build tool that builds code quickly and reliably. It is used to build
the majority of Google's software, and thus it has been designed to handle
build problems present in Google's development environment, including:

* **A massive, shared code repository, in which all software is built from
source.** Bazel has been built for speed, using both caching and parallelism
to achieve this. Bazel is critical to Google's ability to continue
to scale its software development practices as the company grows.

* **An emphasis on automated testing and releases.** Bazel has
been built for correctness and reproducibility, meaning that a build performed
on a continuous build machine or in a release pipeline will generate
bitwise-identical outputs to those generated on a developer's machine.

* **Language and platform diversity.** Bazel's architecture is general enough to
support many different programming languages within Google, and can be
used to build both client and server software targeting multiple
architectures from the same underlying codebase.