### PR TITLE
Date tools: MatthewYork/DateTools

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,7 @@ Last update: 2015-06-18
     - [Key-Value stores](#key-value-stores)
     - [Encryption](#encryption)
   - [Data](#data)
+  - [Date tools](#date-tools)
   - [Macros utilities](#macros-utilities)
   - [Low level](#low-level)
   - [Debugging](#debugging)
@@ -589,6 +590,12 @@ such as JSON representation
 * [ParseKit](https://github.com/itod/parsekit/)
 
 > Objective-C Tokenizer and Parser Generator. Supports Grammars.
+
+## Date tools
+
+* [DateTools](https://github.com/MatthewYork/DateTools)
+
+>  Dates and times made easy in Objective-C
 
 ## Macros utilities
 


### PR DESCRIPTION
![Banner](https://raw.githubusercontent.com/MatthewYork/Resources/master/DateTools/DateToolsHeader.png)

## DateTools

DateTools was written to streamline date and time handling in Objective-C. Classes and concepts from other languages served as an inspiration for DateTools, especially the [DateTime](http://msdn.microsoft.com/en-us/library/system.datetime(v=vs.110).aspx) structure and [Time Period Library](Time Period Library) for .NET. Through these classes and others, DateTools removes the boilerplate required to access date components, handles more nuanced date comparisons, and serves as the foundation for entirely new concepts like Time Periods and their collections.
